### PR TITLE
fix(epl): solve issue on parallax-scrolling

### DIFF
--- a/packages/election2024-president-letters/components/shared/article-image-parallax-scrolling.tsx
+++ b/packages/election2024-president-letters/components/shared/article-image-parallax-scrolling.tsx
@@ -19,21 +19,12 @@ const Div = styled.div<{
   background-position: center center;
   background-repeat: no-repeat;
   background-size: cover;
-  background-image: image-set(
-    ${({ imagesSrc }) =>
-      `url(${imagesSrc.mobileWebP}) type('image/webp'), url(${imagesSrc.mobile}) type('image/jpeg')`}
-  );
+  background-image: ${({ imagesSrc }) => `url(${imagesSrc.mobile})`};
   ${breakpoint.md} {
-    background-image: image-set(
-      ${({ imagesSrc }) =>
-        `url(${imagesSrc.tabletWebP}) type('image/webp'), url(${imagesSrc.tablet}) type('image/jpeg')`}
-    );
+    background-image: ${({ imagesSrc }) => `url(${imagesSrc.tablet})`};
   }
   ${breakpoint.xl} {
-    background-image: image-set(
-      ${({ imagesSrc }) =>
-        `url(${imagesSrc.desktopWebP}) type('image/webp'), url(${imagesSrc.desktop}) type('image/jpeg')`}
-    );
+    background-image: ${({ imagesSrc }) => `url(${imagesSrc.desktop})`};
 
     width: 100%;
     height: 60vw;

--- a/packages/election2024-president-letters/components/shared/article-image-parallax-scrolling.tsx
+++ b/packages/election2024-president-letters/components/shared/article-image-parallax-scrolling.tsx
@@ -29,6 +29,9 @@ const Div = styled.div<{
     width: 100%;
     height: 60vw;
   }
+  @media only screen {
+    background-attachment: scroll;
+  }
 `
 export type ImagesSrc = {
   desktop: string


### PR DESCRIPTION
修復視差滾動相關問題，包含：
1. image-set的type在Safari無法使用問題，詳見[can i use](https://caniuse.com/css-image-set)
2. 因為在手機版safari中，設定`background-attachment: fixed;` 會導致圖片無法正確載入，所以使用media query，在手機版瀏覽器中取消視差滾動效果。詳見[w3cschool](https://www.w3schools.com/howto/howto_css_parallax.asp)